### PR TITLE
Minor updates to make Release Notes consistent across products.

### DIFF
--- a/rst/dev-guide/conf.py
+++ b/rst/dev-guide/conf.py
@@ -37,7 +37,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+#templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -127,7 +127,8 @@ extlinks = {
 rst_epilog = """
 .. |apiservice| replace:: Rackspace Cloud Block Storage API
 .. |no changes| replace:: None for this release.
-.. |contract version| replace:: v1
+.. |contract version| replace:: 1.0
+.. |product name| replace:: Rackspace Cloud Block Storage
 """
 
 

--- a/rst/dev-guide/release-notes.rst
+++ b/rst/dev-guide/release-notes.rst
@@ -4,21 +4,23 @@
 **Release Notes**
 ======================
 
-This section describes, for each release, the new features, changes to existing features, 
-and any known issues.
+Learn about new features, enhancements, known issues,
+resolved issues, and other important details about |apiservice| |contract version| service updates.
+
+.. note:: For information about using the API, see the :ref:`documentation overview <index>`.
 
 .. toctree::
    :maxdepth: 2  
       
-   release-notes/cbs-v1-20150827
-   release-notes/cbs-v1-20150211    
-   release-notes/cbs-v1-20141229
-   release-notes/cbs-v1-20141009
-   release-notes/cbs-v1-20140210  
-   release-notes/cbs-v1-20140206
-   release-notes/cbs-v1-20140128
-   release-notes/cbs-v1-20140102
-   release-notes/cbs-v1-20131021
-   release-notes/cbs-v1-20131003 
-   release-notes/cbs-v1-20130809
-   release-notes/cbs-v1-20121023
+   August 27, 2015 <release-notes/cbs-v1-20150827>
+   February 11, 2015 <release-notes/cbs-v1-20150211>   
+   December 29, 2014 <release-notes/cbs-v1-20141229>
+   October 9, 2014 <release-notes/cbs-v1-20141009>
+   February 10, 2014 <release-notes/cbs-v1-20140210>
+   February 6, 2014 <release-notes/cbs-v1-20140206>
+   January 28, 2014 <release-notes/cbs-v1-20140128>
+   January 2, 2014 <release-notes/cbs-v1-20140102>
+   October 21, 2013 <release-notes/cbs-v1-20131021>
+   October 3, 2013 <release-notes/cbs-v1-20131003>
+   August 9, 2013 <release-notes/cbs-v1-20130809>
+   October 23, 2012 <release-notes/cbs-v1-20121023>


### PR DESCRIPTION
- Updated global variables section in conf.py to change contract version to "1.0" . We'll use v#.# to refer to release version identifiers for services that have them.

- In the Release Notes intro, added a link to top of API doc.

- In the Release Notes, added a navigation title with date to prevent repetition of "API 1.0" in the Release Notes navigation headers.