### PR TITLE
Small changes to flatten send API and auth sections

### DIFF
--- a/rst/dev-guide/common-gs/auth-using-curl.rst
+++ b/rst/dev-guide/common-gs/auth-using-curl.rst
@@ -1,8 +1,5 @@
 .. _authenticate-using-curl:
 
-Authenticating by using cURL
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 Follow these steps to authenticate to the Rackspace Cloud by 
 :ref:`using cURL<how-curl-commands-work>`. 
 

--- a/rst/dev-guide/getting-started/send-request-ovw.rst
+++ b/rst/dev-guide/getting-started/send-request-ovw.rst
@@ -1,18 +1,19 @@
 .. _send-api-requests:
 
-Sending requests to the API by using cURL 
+Send requests to the API
 ------------------------------------------
 
 This Getting Started Guide shows how to send requests by using cURL.
 
-To learn about other ways to use Rackspace Cloud API services, see the following resources:
-     
--  If you are developing applications or automation, try using `Rackspace SDKs`_, the 
-   `Rackspace CLI`_, or `OpenStack client applications`_.
+.. note:: 
+     You can also use Rackspace Cloud API services by using the following methods: 
 
--  For API development, testing and workflow management in a graphical environment, try 
-   interacting with the API by using an application such as
-   `Postman`_  or `RESTClient for Firefox`_.
+     -  If you are developing applications or automation, try using `Rackspace SDKs`_, the
+        `Rackspace CLI`_, or `OpenStack client applications`_.
+
+     -  For API development, testing and workflow management in a graphical environment, try
+        interacting with the API by using an application such as
+        `Postman`_  or `RESTClient for Firefox`_.
    
    
 .. include:: ../common-gs/how-to-use-curl.rst


### PR DESCRIPTION
Because this product doesn't show two methods for sending requests and authentication, we don't need the second-level heading for the send API req and auth sections.  