### PR TITLE
In GSG example cURL, moved -d to end of line for POST and PUT

### DIFF
--- a/rst/dev-guide/getting-started/examples/create-snapshot.rst
+++ b/rst/dev-guide/getting-started/examples/create-snapshot.rst
@@ -24,7 +24,7 @@ and ``"status": "creating"`` indicates that the snapshot is in progress.
 
 .. code:: bash 
 
-   curl -i -X POST -d $API_ENDPOINT/v1/$TENANT_ID/snapshots \
+   curl -i -X POST $API_ENDPOINT/v1/$TENANT_ID/snapshots -d \
       '{
       "snapshot": {
           "display_name": "snap-001",

--- a/rst/dev-guide/getting-started/examples/create-volume.rst
+++ b/rst/dev-guide/getting-started/examples/create-volume.rst
@@ -24,7 +24,7 @@ volume was successfully created.
 
 .. code:: bash 
 
-   curl -i -X POST -d $API_ENDPOINT/v1/$TENANT_ID/volumes \
+   curl -i -X POST $API_ENDPOINT/v1/$TENANT_ID/volumes -d \
     '{ 
     "volume":{ 
     "display_name": "vol-001",    

--- a/rst/dev-guide/getting-started/examples/update-snapshot.rst
+++ b/rst/dev-guide/getting-started/examples/update-snapshot.rst
@@ -17,7 +17,7 @@ request successfully completed.
 
 .. code:: bash 
 
-   curl -i -X PUT -d $API_ENDPOINT/v1/$TENANT_ID/snapshots/yourSnapshotID \
+   curl -i -X PUT $API_ENDPOINT/v1/$TENANT_ID/snapshots/yourSnapshotID  -d \
       '{
        "snapshot":{
            "display_name":"newSnapshotName",

--- a/rst/dev-guide/getting-started/examples/update-volume.rst
+++ b/rst/dev-guide/getting-started/examples/update-volume.rst
@@ -17,7 +17,7 @@ request successfully completed.
 
 .. code:: bash 
 
-   curl -i -X PUT -d $API_ENDPOINT/v1/$TENANT_ID/volumes/yourVolumeID \
+   curl -i -X PUT $API_ENDPOINT/v1/$TENANT_ID/volumes/yourVolumeID -d \
       '{
        "volume":{
            "display_name":"newName",


### PR DESCRIPTION
operations.