### PR TITLE
HOLD - DO NOT MERGE - Add Cinder v2 methods to CBS Dev Guide

### DIFF
--- a/api-docs/api-operations-v2/cbs-snapshots-operations-v2.rst
+++ b/api-docs/api-operations-v2/cbs-snapshots-operations-v2.rst
@@ -1,0 +1,28 @@
+.. _snapshots-operations-v2:
+
+Snapshots
+~~~~~~~~~
+
+
+A snapshot is a point-in-time copy of the data that a volume contains.
+
+When you create, list, update, or delete volumes, the following status values are possible:
+
+* CREATING: The snapshot is being created.
+
+* AVAILABLE: The snapshot is ready for use.
+
+* DELETING: The snapshot is being deleted.
+
+* ERROR: An error occurred during snapshot creation.
+
+* ERROR_DELETING: An error occurred during snapshot deletion.
+
+
+.. include:: methods-v2/post-create-snapshot-v2.rst
+.. include:: methods-v2/get-list-snapshots-v2.rst
+.. include:: methods-v2/get-list-snapshots-(detailed)-v2.rst
+.. include:: methods-v2/get-show-snapshot-details-v2.rst
+.. include:: methods-v2/put-update-snapshot-v2.rst
+.. include:: methods-v2/delete-snapshot-v2.rst
+.. include:: methods-v2/get-show-snapshot-metadata-v2.rst

--- a/api-docs/api-operations-v2/cbs-volume-types-operations-v2.rst
+++ b/api-docs/api-operations-v2/cbs-volume-types-operations-v2.rst
@@ -1,0 +1,9 @@
+.. _volume-types-operations-v2:
+
+Volume types
+~~~~~~~~~~~~~
+
+Use volume type operations to list volume types and show volume type details.    
+
+.. include:: methods-v2/get-list-volume-types-v2.rst
+.. include:: methods-v2/get-show-volume-type-details-v2.rst       

--- a/api-docs/api-operations-v2/cbs-volumes-operations-v2.rst
+++ b/api-docs/api-operations-v2/cbs-volumes-operations-v2.rst
@@ -1,0 +1,41 @@
+.. _volumes-operations-v2:
+
+Volumes
+~~~~~~~  
+   
+A volume is a detachable block storage device. You can think of it as a USB hard drive. You can attach a volume to one instance at a time.
+
+The ``snapshot_id`` and ``source_volid`` parameters specify the ID of the snapshot or volume from which this volume originates. If the volume was not created from a snapshot or source volume, these values are null. 
+
+When you make an API call to create, list, or delete volumes, the following volume status values are possible:
+
+* CREATING: The snapshot is being created.
+
+* AVAILABLE: The snapshot is ready for use.
+
+* ATTACHING: The volume is attaching to an instance.
+
+* IN-USE: The volume is attached to an instance.
+
+* DELETING: The snapshot is being deleted.
+
+* ERROR: An error occurred during snapshot creation.
+
+* ERROR_DELETING: An error occurred during snapshot deletion.
+
+* BACKING-UP: The volume is being backed up.
+
+* RESTORING-BACKUP: A backup is being restored to the volume.
+
+* ERROR-RESTORING: A backup restoration error occurred.
+
+* ERROR_EXTENDING: An error occurred while attempting to extend a volume.
+
+
+   
+.. include:: methods-v2/post-create-volume-v2.rst
+.. include:: methods-v2/get-list-volumes-v2.rst
+.. include:: methods-v2/get-list-volumes-(detailed)-v2.rst
+.. include:: methods-v2/get-show-volume-v2.rst
+.. include:: methods-v2/put-update-volume-v2.rst
+.. include:: methods-v2/delete-volume-v2.rst

--- a/api-docs/api-operations-v2/index-v2.rst
+++ b/api-docs/api-operations-v2/index-v2.rst
@@ -1,0 +1,14 @@
+
+
+.. meta::
+   :description: Rackspace Cloud Block Storage API Reference
+   :keywords: Rackspace, Cloud Block Storage ReST API, API resources, API methods
+       
+.. toctree:: 
+   :maxdepth: 2
+   
+   cbs-volumes-operations-v2
+   cbs-volume-types-operations-v2
+   cbs-snapshots-operations-v2
+
+

--- a/api-docs/api-operations-v2/methods-v2/delete-snapshot-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/delete-snapshot-v2.rst
@@ -1,0 +1,65 @@
+
+.. _delete-snapshot-v2:
+
+Delete snapshot
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    DELETE /v2/{tenant_id}/snapshots/{snapshot_id}
+
+This operation deletes a snapshot.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|202                       |Accepted                 |The request has been     | 
+|                          |                         |fulfilled and a resource |
+|                          |                         |was created.             |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{snapshot_id}             |UUID *(Required)*        |The UUID of the snapshot.|
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+
+
+This operation does not return a response body.
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/delete-volume-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/delete-volume-v2.rst
@@ -1,0 +1,93 @@
+
+.. _delete-volume-v2:
+
+Delete volume
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    DELETE /v2/{tenant_id}/volumes/{volume_id}
+
+This operation deletes a volume.
+
+.. note::
+   If a snapshot of the volume exists, you cannot delete the volume until you delete the snapshot.
+
+
+
+**Preconditions**
+
+-   Volume status must be ``available``, ``in-use``, ``error``, or ``error_restoring``.
+
+-   You cannot already have a snapshot of the volume.
+
+-   You cannot delete a volume that is in a migration.
+
+**Asynchronous postconditions**
+
+-   The volume is deleted in volume index.
+
+-   The volume managed by Cloud Block Storage is deleted in storage node.
+
+**Troubleshooting**
+
+-   If volume status remains in ``deleting`` or becomes ``error_deleting`` the request failed. Ensure you meet the preconditions then investigate the storage back end.
+
+-   The volume managed by OpenStack Block Storage is not deleted from the storage system.
+
+   
+   
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|202                       |Accepted                 |The request has been     |
+|                          |                         |accepted for processing. |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{volume_id}               |UUID *(Required)*        |The UUID of              |
+|                          |                         |an existing volume.      |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+
+
+This operation does not return a response body.
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-list-snapshots-(detailed)-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-list-snapshots-(detailed)-v2.rst
@@ -1,0 +1,138 @@
+
+.. _get-list-snapshots-detail-v2:
+
+List snapshots (detailed)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/snapshots/detail
+
+This operation lists detailed information for all Cloud Block Storage snapshots that the tenant who submits the request can access.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshots**             |Dict                     |A snapshots object.      |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\ **status**    |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshots.\               |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\ **size**      |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshots.\ **id**        |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\ **name**      |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |Integer                  |A percentage value for   |
+|**os-extended-snapshot-   |                         |the build progress.      |
+|attributes:progress**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |UUID                     |The UUID of the owning   |
+|**os-extended-snapshot-   |                         |project.                 |
+|attributes:project_id**   |                         |                         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+   
+
+
+
+
+
+**Example List snapshots (detailed): JSON response**
+
+
+.. code::
+
+   
+   {
+       "snapshots": [
+           {
+               "status": "available",
+               "metadata": {
+                   "name": "test"
+               },
+               "os-extended-snapshot-attributes:progress": "100%",
+               "name": "test-volume-snapshot",
+               "volume_id": "173f7b48-c4c1-4e70-9acc-086b39073506",
+               "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+               "created_at": "2015-11-29T02:25:51.000000",
+               "size": 1,
+               "id": "b1323cda-8e4b-41c1-afc5-2fc791809c8c",
+               "description": "volume snapshot"
+           }
+       ]
+   }
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-list-snapshots-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-list-snapshots-v2.rst
@@ -1,0 +1,177 @@
+
+.. _get-list-snapshots-v2:
+
+List snapshots
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/snapshots
+
+This operation lists summary information for all Cloud Block Storage snapshots that the tenant who submits the request can access.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+
+This table shows the query parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|sort_key                  |String *(Optional)*      |Sorts by an attribute. A |
+|                          |                         |valid value is ``name``, |
+|                          |                         |``status``, ``container-f|
+|                          |                         |ormat``, ``disk-format``,|
+|                          |                         |``size``, ``id``,        |
+|                          |                         |``created-at``, or       |
+|                          |                         |``updated-at``.          |
+|                          |                         |Default is               |
+|                          |                         |``created-at``.          |
+|                          |                         |The API uses the         |
+|                          |                         |natural sorting direction|
+|                          |                         |of the ``sort-key``      |
+|                          |                         |attribute value.         |
++--------------------------+-------------------------+-------------------------+
+|sort_dir                  |String *(Optional)*      |Sorts by one or more sets|
+|                          |                         |of attribute and sort    |
+|                          |                         |direction combinations.  |
+|                          |                         |If you omit the sort     |
+|                          |                         |direction in a set,      |
+|                          |                         |default is ``desc``      |
+|                          |                         |(descending).            |
++--------------------------+-------------------------+-------------------------+
+|limit                     |Integer *(Optional)*     |Requests a page size of  |
+|                          |                         |items. Returns a number  |
+|                          |                         |of items up to a limit   |
+|                          |                         |value. Use the ``limit`` |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+|marker                    |String *(Optional)*      |The ID of the last-seen  |
+|                          |                         |item. Use the ``limit``  |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict                     |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **status**     |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshot.\                |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **size**       |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **id**         |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **name**       |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+**Example List snapshots: JSON response**
+
+
+.. code::
+
+   {
+       "snapshots": [
+           {
+               "status": "available",
+               "metadata": {
+                   "name": "test"
+               },
+               "name": "test-volume-snapshot",
+               "volume_id": "173f7b48-c4c1-4e70-9acc-086b39073506",
+               "created_at": "2015-11-29T02:25:51.000000",
+               "size": 1,
+               "id": "b1323cda-8e4b-41c1-afc5-2fc791809c8c",
+               "description": "volume snapshot"
+           }
+       ]
+   }   
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-list-volume-types-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-list-volume-types-v2.rst
@@ -1,0 +1,154 @@
+
+.. _get-list-volume-types-v2:
+
+List volume types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/types
+
+This operation lists volume types.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+This table shows the query parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|sort_key                  |String *(Optional)*      |Sorts by an attribute. A |
+|                          |                         |valid value is ``name``, |
+|                          |                         |``status``, ``container-f|
+|                          |                         |ormat``, ``disk-format``,|
+|                          |                         |``size``, ``id``,        |
+|                          |                         |``created-at``, or       |
+|                          |                         |``updated-at``.          |
+|                          |                         |Default is               |
+|                          |                         |``created-at``.          |
+|                          |                         |The API uses the         |
+|                          |                         |natural sorting direction|
+|                          |                         |of the ``sort-key``      |
+|                          |                         |attribute value.         |
++--------------------------+-------------------------+-------------------------+
+|sort_dir                  |String *(Optional)*      |Sorts by one or more sets|
+|                          |                         |of attribute and sort    |
+|                          |                         |direction combinations.  |
+|                          |                         |If you omit the sort     |
+|                          |                         |direction in a set,      |
+|                          |                         |default is ``desc``      |
+|                          |                         |(descending).            |
++--------------------------+-------------------------+-------------------------+
+|limit                     |Integer *(Optional)*     |Requests a page size of  |
+|                          |                         |items. Returns a number  |
+|                          |                         |of items up to a limit   |
+|                          |                         |value. Use the ``limit`` |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+|marker                    |String *(Optional)*      |The ID of the last-seen  |
+|                          |                         |item. Use the ``limit``  |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response 
+""""""""""""""""
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume-type**           |List                     |A list of ``volume_type``|
+|                          |                         |objects.                 |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\             |Dict                     |A set of key and value   |
+|**extra_specs**           |                         |pairs that contains the  |
+|                          |                         |specifications for a     |
+|                          |                         |volume type.             |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\ **id**      |UUID                     |The UUID of the volume   |
+|                          |                         |type.                    |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\ **name**    |String                   |The name of the volume   |
+|                          |                         |type.                    |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+**Example List volume types: JSON response**
+
+
+.. code::
+
+   {
+       "volume_types": [
+           {
+               "extra_specs": {
+                   "capabilities": "gpu"
+               },
+               "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+               "name": "SSD"
+           },
+           {
+               "extra_specs": {},
+               "id": "8eb69a46-df97-4e41-9586-9a40a7533803",
+               "name": "SATA"
+           }
+       ]
+   }
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-list-volumes-(detailed)-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-list-volumes-(detailed)-v2.rst
@@ -1,0 +1,313 @@
+
+.. _get-list-volumes-detail-v2:
+
+List volumes (detailed)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/volumes/detail
+
+This operation lists detailed information for all Cloud Block Storage volumes that the tenant who submits the request can access.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+This table shows the query parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|sort                      |String *(Optional)*      |Comma-separated list of  |
+|                          |                         |sort keys and optional   |
+|                          |                         |sort directions in the   |
+|                          |                         |form of <key>[:<direction|
+|                          |                         |>]. A valid direction is |
+|                          |                         |``asc`` (ascending) or   |
+|                          |                         |``desc`` (descending).   |
++--------------------------+-------------------------+-------------------------+
+|limit                     |Integer *(Optional)*     |Requests a page size of  |
+|                          |                         |items. Returns a number  |
+|                          |                         |of items up to a limit   |
+|                          |                         |value. Use the ``limit`` |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+|marker                    |String *(Optional)*      |The ID of the last-seen  |
+|                          |                         |item. Use the ``limit``  |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volumes**               |Dict                     |A list of volume objects.|
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **status**      |String                   |The volume status.       |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |String                   |The volume migration     |
+|**migration_status**      |                         |status.                  |                   
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **user_id**     |UUID                     |The UUID of the user.    |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |List                     |Instance attachment      |
+|**attachments**           |                         |information.             |
+|                          |                         |If this volume is        |
+|                          |                         |attached to a server     |
+|                          |                         |instance, the            |
+|                          |                         |attachments list includes|
+|                          |                         |the UUID of the attached |
+|                          |                         |server, an attachment    |
+|                          |                         |UUID, the name of the    |
+|                          |                         |attached host, if any,   |
+|                          |                         |the volume UUID, the     |
+|                          |                         |device, and the device   |
+|                          |                         |UUID. Otherwise, this    |
+|                          |                         |list is empty.           |                   
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **links**       |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |String                   |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |Boolean                  |Indicates if the volume  |
+|**bootable**              |                         |is bootable. You can boot|
+|                          |                         |an instance from a       |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |Boolean                  |Indicates if the volume  |
+|**encrypted**             |                         |is encrypted.            |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |DateTime                 |The date and time when   |
+|**created_at**            |                         |volume was created. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |String                   |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|volumes.\                 |DateTime                 |The date and time when   |
+|**updated_at**            |                         |volume was updated. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC. If the value is not |
+|                          |                         |set, the value is        |
+|                          |                         |``null``.                |
++--------------------------+-------------------------+-------------------------+ 
+|volumes.\                 |String                   |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |String                   |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |String                   |The volume replication   |
+|**replication_status**    |                         |status.                  |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |UUID                     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |UUID                     |The UUID of the source   |
+|**source_volid**          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |UUID                     |The UUID of the source   |
+|**snapshot_id**           |                         |volume snapshot. The API |
+|                          |                         |creates a new volume     |
+|                          |                         |snapshot with the same   |
+|                          |                         |size as the source volume|
+|                          |                         |snapshot.                |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |Boolean                  |If ``true``, this volume |
+|**multiattach**           |                         |can attach to more than  |
+|                          |                         |server instance.         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volumes.\                 |UUID                     |The UUID of the volume.  |
+|**id**                    |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **size**        |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **links**       |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+**Example List volumes (detailed): JSON response**
+
+
+.. code::
+
+   {
+       "volumes": [
+           {
+              "migration_status": null,
+               "attachments": [
+                   {
+                       "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+                       "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+                       "host_name": null,
+                       "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                       "device": "/dev/vdb",
+                       "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
+                   }
+               ],
+               "links": [
+                   {
+                       "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                       "rel": "self"
+                   },
+                   {
+                       "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                       "rel": "bookmark"
+                   }
+               ],
+               "availability_zone": "nova",
+               "os-vol-host-attr:host": "difleming@lvmdriver-1#lvmdriver-1",
+               "encrypted": false,
+               "os-volume-replication:extended_status": null,
+               "replication_status": "disabled",
+               "snapshot_id": null,
+               "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+               "size": 2,
+               "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+               "os-vol-tenant-attr:tenant_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+               "os-vol-mig-status-attr:migstat": null,
+               "metadata": {
+                   "readonly": "False",
+                   "attached_mode": "rw"
+               },
+               "status": "in-use",
+               "description": null,
+               "multiattach": true,
+               "os-volume-replication:driver_data": null,
+               "source_volid": null,
+               "consistencygroup_id": null,
+               "os-vol-mig-status-attr:name_id": null,
+               "name": "test-volume-attachments",
+               "bootable": "false",
+               "created_at": "2015-11-29T03:01:44.000000",
+               "volume_type": "lvmdriver-1"
+           },
+           {
+               "migration_status": null,
+               "attachments": [],
+               "links": [
+                   {
+                       "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/173f7b48-c4c1-4e70-9acc-086b39073506",
+                       "rel": "self"
+                   },
+                   {
+                       "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/173f7b48-c4c1-4e70-9acc-086b39073506",
+                       "rel": "bookmark"
+                   }
+               ],
+               "availability_zone": "nova",
+               "os-vol-host-attr:host": "difleming@lvmdriver-1#lvmdriver-1",
+               "encrypted": false,
+               "os-volume-replication:extended_status": null,
+               "replication_status": "disabled",
+               "snapshot_id": null,
+               "id": "173f7b48-c4c1-4e70-9acc-086b39073506",
+               "size": 1,
+               "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+               "os-vol-tenant-attr:tenant_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+               "os-vol-mig-status-attr:migstat": null,
+               "metadata": {},
+               "status": "available",
+               "volume_image_metadata": {
+                   "kernel_id": "8a55f5f1-78f7-4477-8168-977d8519342c",
+                   "checksum": "eb9139e4942121f22bbc2afc0400b2a4",
+                   "min_ram": "0",
+                   "ramdisk_id": "5f6bdf8a-92db-4988-865b-60bdd808d9ef",
+                   "disk_format": "ami",
+                   "image_name": "cirros-0.3.4-x86_64-uec",
+                   "image_id": "b48c53e1-9a96-4a5a-a630-2e74ec54ddcc",
+                   "container_format": "ami",
+                   "min_disk": "0",
+                   "size": "25165824"
+               },
+               "description": "",
+               "multiattach": false,
+               "os-volume-replication:driver_data": null,
+               "source_volid": null,
+               "consistencygroup_id": null,
+               "os-vol-mig-status-attr:name_id": null,
+               "name": "test-volume",
+               "bootable": "true",
+               "created_at": "2015-11-29T02:25:18.000000",
+               "volume_type": "lvmdriver-1"
+           }
+       ]
+   }
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-list-volumes-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-list-volumes-v2.rst
@@ -1,0 +1,148 @@
+
+.. _get-list-volumes-v2:
+
+List volumes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/volumes
+
+This operation lists summary information for all Cloud Block Storage volumes that the tenant who submits the request can access.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID   *(Required)*      |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+This table shows the query parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|sort                      |String *(Optional)*      |Comma-separated list of  |
+|                          |                         |sort keys and optional   |
+|                          |                         |sort directions in the   |
+|                          |                         |form of <key>[:<direction|
+|                          |                         |>]. A valid direction is |
+|                          |                         |``asc`` (ascending) or   |
+|                          |                         |``desc`` (descending).   |
++--------------------------+-------------------------+-------------------------+
+|limit                     |Integer *(Optional)*     |Requests a page size of  |
+|                          |                         |items. Returns a number  |
+|                          |                         |of items up to a limit   |
+|                          |                         |value. Use the ``limit`` |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+|marker                    |String *(Optional)*      |The ID of the last-seen  |
+|                          |                         |item. Use the ``limit``  |
+|                          |                         |parameter to make an     |
+|                          |                         |initial limited request  |
+|                          |                         |and use the ID of the    |
+|                          |                         |last-seen item from the  |
+|                          |                         |response as the          |
+|                          |                         |``marker`` parameter     |
+|                          |                         |value in a subsequent    |
+|                          |                         |limited request.         |
++--------------------------+-------------------------+-------------------------+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volumes**               |List                     |A list of volume objects.|
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **name**        |String                   |The volume name.         |
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **id**          |UUID                     |The UUID of the volume.  |             
++--------------------------+-------------------------+-------------------------+
+|volumes.\ **links**       |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+**Example List volumes: JSON response**
+
+
+.. code::
+
+   {
+        "volumes": [
+            {
+               "id": "45baf976-c20a-4894-a7c3-c94b7376bf55",
+               "links": [
+                   {
+                       "href": "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/45baf976-c20a-4894-a7c3-c94b7376bf55",
+                       "rel": "self"
+                   },
+                   {
+                       "href": "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/45baf976-c20a-4894-a7c3-c94b7376bf55",
+                       "rel": "bookmark"
+                   }
+               ],
+               "name": "vol-004"
+           },
+           {
+               "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+               "links": [
+                   {
+                       "href": "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                       "rel": "self"
+                   },
+                   {
+                    "href": "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                       "rel": "bookmark"
+                   }
+               ],
+               "name": "vol-003"
+          }
+    ]   
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-show-snapshot-details-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-show-snapshot-details-v2.rst
@@ -1,0 +1,138 @@
+
+.. _get-show-snapshot-details-v2:
+
+Show snapshot details
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/snapshots/{snapshot_id}
+
+This operation shows snapshot details.
+
+.. note::
+   The ``os-extended-snapshot-attributes:progress`` field in the response body shows snapshot progress. See the example response.
+   
+   
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{snapshot_id}             |UUID *(Required)*        |The UUID of the snapshot.|
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict                     |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **status**     |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshot.\                |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **size**       |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **id**         |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **name**       |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |Integer                  |A percentage value for   |
+|**os-extended-snapshot-   |                         |the build progress.      |
+|attributes:progress**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |UUID                     |The UUID of the owning   |
+|**os-extended-snapshot-   |                         |project.                 |
+|attributes:project_id**   |                         |                         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+
+
+
+**Example Show snapshot details: JSON response**
+
+
+.. code::
+
+   {
+       "snapshot": {
+           "status": "available",
+           "os-extended-snapshot-attributes:progress": "100%",
+           "description": "Daily backup",
+           "created_at": "2013-02-25T04:13:17.000000",
+           "metadata": {},
+           "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+           "os-extended-snapshot-attributes:project_id": "0c2eba2c5af04d3f9e9d0d410b371fde",
+           "size": 1,
+           "id": "2bb856e1-b3d8-4432-a858-09e4ce939389",
+           "name": "snap-001"
+       }
+   }
+   
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-show-snapshot-metadata-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-show-snapshot-metadata-v2.rst
@@ -1,0 +1,135 @@
+
+.. _get-show-snapshot-metadata-v2:
+
+Show snapshot metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/snapshots/{snapshot_id}/metadata
+
+This operation shows the metadata for the specified snapshot.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{snapshot_id}             |UUID *(Required)*        |The UUID of the snapshot.|
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict                     |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **status**     |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshot.\                |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **size**       |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **id**         |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **name**       |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |Integer                  |A percentage value for   |
+|**os-extended-snapshot-   |                         |the build progress.      |
+|attributes:progress**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|snapshots.\               |UUID                     |The UUID of the owning   |
+|**os-extended-snapshot-   |                         |project.                 |
+|attributes:project_id**   |                         |                         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+**Example Show snapshot metadata: JSON response**
+
+
+.. code::
+
+   
+   
+   {
+       "snapshot": {
+           "status": "available",
+           "os-extended-snapshot-attributes:progress": "0%",
+           "description": null,
+           "created_at": "2014-05-06T17:59:52.000000",
+           "metadata": {
+               "key": "v1"
+           },
+           "volume_id": "ebd80b99-bc3d-4154-9d28-5583baa80580",
+           "os-extended-snapshot-attributes:project_id": "7e0105e19cd2466193729ef78b604f79",
+           "size": 10,
+           "id": "dfcd17fe-3b64-44ba-b95f-1c9c7109ef95",
+           "name": "my-snapshot"
+       }
+   }
+   
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-show-volume-type-details-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-show-volume-type-details-v2.rst
@@ -1,0 +1,110 @@
+
+.. _get-show-volume-type-details-v2:
+
+Show volume type details
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/types/{volume_type_id}
+
+This operation shows volume type details.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{volume_type_id}          |UUID *(Required)*        |The UUID for an existing |
+|                          |                         |volume type.             |
++--------------------------+-------------------------+-------------------------+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+This table shows the body parameters for the response:
+
+
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume-type**           |List                     |A list of ``volume_type``|
+|                          |                         |objects.                 |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\ **id**      |UUID                     |The UUID of the volume   |  
+|                          |                         |type.                    |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\ **name**    |String                   |The name of the volume   |
+|                          |                         |type.                    |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\             |String                   |The volume type          |
+|**description**           |                         |description.             |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\             |Boolean                  |Indicates if the volume  |
+|**is_public**             |                         |type is public           |
+|                          |                         |(``true``).              |
++--------------------------+-------------------------+-------------------------+
+|volume-type.\             |Dict                     |A set of key and value   |
+|**extra_specs**           |                         |pairs that contains the  |
+|                          |                         |specifications for a     |
+|                          |                         |volume type.             |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+**Example Show volume type details: JSON response**
+
+
+.. code::
+
+   {
+       "volume_type": {
+           "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+           "name": "vol-type-001",
+           "description": "volume type 001",
+           "is_public": "true",
+           "extra_specs": {
+               "capabilities": "gpu"
+           }
+       }
+   }
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/get-show-volume-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/get-show-volume-v2.rst
@@ -1,0 +1,215 @@
+
+.. _get-show-volume-v2:
+
+Show volume
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    GET /v2/{tenant_id}/volumes/{volume_id}
+
+This operation shows details for a volume.
+
+**Preconditions:**
+
+-  This volume must exist.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{volume_id}               |UUID *(Required)*        |The UUID of              |
+|                          |                         |an existing volume.      |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This operation does not accept a request body.
+
+
+
+
+Response
+""""""""""""""""
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume**                |Dict                     |A volume object.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **status**       |String                   |The volume status.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume migration     |
+|**migration_status**      |                         |status.                  |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **user_id**      |UUID                     |The UUID of the user.    |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |List                     |Instance attachment      |
+|**attachments**           |                         |information.             |
+|                          |                         |If this volume is        |
+|                          |                         |attached to a server     |
+|                          |                         |instance, the            |
+|                          |                         |attachments list includes|
+|                          |                         |the UUID of the attached |
+|                          |                         |server, an attachment    |
+|                          |                         |UUID, the name of the    |
+|                          |                         |attached host, if any,   |
+|                          |                         |the volume UUID, the     |
+|                          |                         |device, and the device   |
+|                          |                         |UUID. Otherwise, this    |
+|                          |                         |list is empty.           |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **links**        |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**bootable**              |                         |is bootable. You can boot|
+|                          |                         |an instance from a       |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**encrypted**             |                         |is encrypted.            |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |DateTime                 |The date and time when   |
+|**created_at**            |                         |volume was created. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |DateTime                 |The date and time when   |
+|**updated_at**            |                         |volume was updated. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC. If the value is not |
+|                          |                         |set, the value is        |
+|                          |                         |``null``.                |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |String                   |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume replication   |
+|**replication_status**    |                         |status.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**source_volid**          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**snapshot_id**           |                         |volume snapshot. The API |
+|                          |                         |creates a new volume     |
+|                          |                         |snapshot with the same   |
+|                          |                         |size as the source volume|
+|                          |                         |snapshot.                |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |If ``true``, this volume |
+|**multiattach**           |                         |can attach to more than  |
+|                          |                         |server instance.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the volume.  |
+|**id**                    |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **size**         |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+
+
+
+
+**Example Show volume: JSON response**
+
+
+.. code::
+
+   {
+       "volume": {
+           "status": "available",
+           "attachments": [],
+           "links": [
+               {
+                   "href": "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                   "rel": "bookmark"
+               }
+           ],
+           "availability_zone": "nova",
+           "bootable": "false",
+           "os-vol-host-attr:host": "ip-10-168-107-25",
+           "source_volid": null,
+           "snapshot_id": null,
+           "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+           "description": "Super volume.",
+           "name": "vol-002",
+           "created_at": "2013-02-25T02:40:21.000000",
+           "volume_type": "None",
+           "os-vol-tenant-attr:tenant_id": "0c2eba2c5af04d3f9e9d0d410b371fde",
+           "size": 1,
+           "os-volume-replication:driver_data": null,
+           "os-volume-replication:extended_status": null,
+           "metadata": {
+               "contents": "not junk"
+           }
+       }
+   }
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/post-create-snapshot-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/post-create-snapshot-v2.rst
@@ -1,0 +1,178 @@
+
+
+.. _post-create-snapshot-v2:
+
+Create snapshot
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    POST /v2/{tenant_id}/snapshots
+
+This operation creates a snapshot.
+
+A snapshot is a point-in-time, complete copy of the volume. You can create a volume from a snapshot.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|202                       |Accepted                 |The request and that it  |
+|                          |                         |has been accepted for    |
+|                          |                         |processing, although it  |
+|                          |                         |may not be processed     |
+|                          |                         |immediately.             |
++--------------------------+-------------------------+-------------------------+
+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This table shows the body parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict *(Required)*        |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String *(Optional)*      |The name of the snapshot.|
+|**name**                  |                         |Default is ``None``.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String *(Optional)*      |A description of the     |
+|**description**           |                         |snapshot. Default is     |
+|                          |                         |``None``.                |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **volume_id**  |UUID *(Optional)*        |If the snapshot was      |
+|                          |                         |created from a volume,   |
+|                          |                         |the volume ID.           |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **force**      |Boolean *(Optional)*     |Indicates whether to     |
+|                          |                         |snapshot, even if the    |
+|                          |                         |volume is attached.      |
+|                          |                         |Default is ``False``.    |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **new_size**   |Integer *(Optional)*     |The size for the volume, |
+|                          |                         |in gibibyte (GiB).       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+
+**Example Create snapshot: JSON request**
+
+
+.. code::
+
+   {
+        "snapshot": {
+            "name": "snap-001",
+            "description": "Daily backup",
+            "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+            "force": true
+       }
+   }   
+
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict                     |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **status**     |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshot.\                |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **size**       |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **id**         |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **name**       |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+   
+
+
+
+
+
+**Example Create snapshot: JSON response**
+
+
+.. code::
+
+   {
+       "snapshot": {
+           "status": "creating",
+           "description": "Daily backup",
+           "created_at": "2013-02-25T03:56:53.081642",
+           "metadata": {},
+           "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+           "size": 1,
+           "id": "ffa9bc5e-1172-4021-acaf-cdcd78a9584d",
+           "name": "snap-001"
+       }
+   }
+   
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/post-create-volume-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/post-create-volume-v2.rst
@@ -1,0 +1,322 @@
+
+.. _post-create-volume-v2:
+
+Create volume
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    POST /v2/{tenant_id}/volumes
+
+This operation creates a volume.
+
+To create a bootable volume, include the UUID of the image from which you want to 
+create the volume in the ``imageRef`` attribute in the request body.
+
+**Preconditions**
+
+-   You must have enough volume storage quota remaining to create a volume of size requested.
+
+**Asynchronous postconditions**
+
+-   With correct permissions, you can see the volume status as ``available`` through API calls.
+
+-   With correct access, you can see the created volume in the storage system that Cloud Block Storage manages.
+
+**Troubleshooting**
+
+-   If volume status remains ``creating`` or shows another error status, the request failed. Ensure you meet 
+    the preconditions, and then investigate the storage back end.
+
+
+
+
+
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|202                       |Accepted                 |The request and that it  |
+|                          |                         |has been accepted for    |
+|                          |                         |processing, although it  |
+|                          |                         |may not be processed     |
+|                          |                         |immediately.             |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a                        |
+|                          |                         |multi-tenancy cloud.     |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This table shows the body parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume**                |Dict *(Required)*        |A volume object.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **size**         |Integer *(Required)*     |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |To create a volume from  |
+|**snapshot_id**           |                         |existing snapshot,       |
+|                          |                         |specify the UUID of the  |
+|                          |                         |volume snapshot. The     |
+|                          |                         |volume is created in the |
+|                          |                         |same availability zone   |
+|                          |                         |and with the same size   |
+|                          |                         |as the snapshot.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |The UUID of the source   |
+|**source_volid**          |                         |volume. The API creates  |
+|                          |                         |a new volume with the    |
+|                          |                         |same size as the source  |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean *(Optional)*     |To enable a volume to    |
+|**multiattach**           |                         |attach to more than one  |
+|                          |                         |server, set the value to |
+|                          |                         |``true``. The default is |
+|                          |                         |``false``.               |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID    *(Optional)*     |The UUID of the primary  |
+|**source_replica**        |                         |volume to clone.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID    *(Optional)*     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Dict   *(Optional)*      |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |The UUID of the image    |
+|**imageRef**              |                         |from which you want to   |
+|                          |                         |create a volume.         |
+|                          |                         |Required to create a     |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+
+**Example Create volume: JSON request**
+
+
+.. code::
+
+   {
+        "volume": {
+            "size": 10,
+            "availability_zone": null,
+            "source_volid": null,
+            "description": null,
+            "multiattach ": false,
+            "snapshot_id": null,
+            "name": null,
+            "imageRef": null,
+            "volume_type": null,
+            "metadata": {},
+            "source_replica": null,
+            "consistencygroup_id": null
+        }
+    }   
+
+
+
+
+
+Response
+""""""""""""""""
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume**                |Dict                     |A volume object.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **status**       |String                   |The volume status.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume migration     |
+|**migration_status**      |                         |status.                  |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **user_id**      |UUID                     |The UUID of the user.    |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |List                     |Instance attachment      |
+|**attachments**           |                         |information.             |
+|                          |                         |If this volume is        |
+|                          |                         |attached to a server     |
+|                          |                         |instance, the            |
+|                          |                         |attachments list includes|
+|                          |                         |the UUID of the attached |
+|                          |                         |server, an attachment    |
+|                          |                         |UUID, the name of the    |
+|                          |                         |attached host, if any,   |
+|                          |                         |the volume UUID, the     |
+|                          |                         |device, and the device   |
+|                          |                         |UUID. Otherwise, this    |
+|                          |                         |list is empty.           |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **links**        |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**bootable**              |                         |is bootable. You can boot|
+|                          |                         |an instance from a       |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**encrypted**             |                         |is encrypted.            |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |DateTime                 |The date and time when   |
+|**created_at**            |                         |volume was created. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |DateTime                 |The date and time when   |
+|**updated_at**            |                         |volume was updated. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC. If the value is not |
+|                          |                         |set, the value is        |
+|                          |                         |``null``.                |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |String                   |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume replication   |
+|**replication_status**    |                         |status.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**source_volid**          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**snapshot_id**           |                         |volume snapshot. The API |
+|                          |                         |creates a new volume     |
+|                          |                         |snapshot with the same   |
+|                          |                         |size as the source volume|
+|                          |                         |snapshot.                |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |If ``true``, this volume |
+|**multiattach**           |                         |can attach to more than  |
+|                          |                         |server instance.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the volume.  |
+|**id**                    |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **size**         |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+
+
+**Example Create volume: JSON response**
+
+
+.. code::
+
+    {
+        "volume": {
+            "status": "creating",
+            "migration_status": null,
+            "user_id": "0eea4eabcf184061a3b6db1e0daaf010",
+            "attachments": [],
+            "links": [
+                {
+                    "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "rel": "self"
+                },
+                {
+                    "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "nova",
+            "bootable": "false",
+            "encrypted": false,
+            "created_at": "2015-11-29T03:01:44.000000",
+            "description": null,
+            "updated_at": null,
+            "volume_type": "lvmdriver-1",
+            "name": "test-volume-attachments",
+            "replication_status": "disabled",
+            "consistencygroup_id": null,
+            "source_volid": null,
+            "snapshot_id": null,
+            "multiattach": false,
+            "metadata": {},
+            "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "size": 2
+        }
+    }
+
+
+.. _Next Generation Cloud Servers Developer Guide: https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#put-attach-volume-to-server-servers-server-id-os-volume-attachments

--- a/api-docs/api-operations-v2/methods-v2/put-update-snapshot-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/put-update-snapshot-v2.rst
@@ -1,0 +1,156 @@
+
+.. _put-update-snapshot-v2:
+
+Update snapshot
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    PUT /v2/{tenant_id}/snapshots/{snapshot_id}
+
+This operation updates a specified snapshot.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{snapshot_id}             |UUID *(Required)*        |The UUID of the snapshot.|
++--------------------------+-------------------------+-------------------------+
+
+
+
+This table shows the body parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict *(Required)*        |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String *(Optional)*      |The name of the snapshot.|
+|**name**                  |                         |Default is ``None``.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String *(Optional)*      |A description of the     |
+|**description**           |                         |snapshot. Default is     |
+|                          |                         |``None``.                |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **new_size**   |Integer *(Optional)*     |The size for the volume, |
+|                          |                         |in gibibyte (GiB).       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+   
+
+
+
+**Example Update snapshot: JSON request**
+
+
+.. code::
+
+   {
+       "snapshot":{
+           "name":"snap-002”,
+           "description":"This is yet, another snapshot."
+       }
+   }
+
+
+
+
+
+Response
+""""""""""""""""
+
+
+
+
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**snapshot**              |Dict                     |A snapshot object.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **status**     |String                   |The snapshot status.     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |String                   |The snapshot description.|
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|snapshot.\                |DateTime                 |The date and time when   |
+|**created_at**            |                         |the snapshot was created.|
+|                          |                         |The format is ISO8601.   |
+|                          |                         |For example,             |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm. The +/- value, if |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |snapshot, if any.        |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\                |UUID                     |The UUID of the volume   |
+|**volume_id**             |                         |if the snapshot was      |
+|                          |                         |created from a volume.   |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **size**       |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **id**         |UUID                     |The snapshot UUID.       |
++--------------------------+-------------------------+-------------------------+
+|snapshot.\ **name**       |String                   |The snapshot name.       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+
+**Example Update snapshot: JSON response**
+
+
+.. code::
+
+   {
+       "snapshot":{
+           "created_at":"2013-02-20T08:11:34.000000",
+           "description":"This is yet, another snapshot",
+           "name”:”snap-002“,
+           "id":"4b502fcb-1f26-45f8-9fe5-3b9a0a52eaf2",
+           "size":1,
+           "status":"available",
+           "volume_id":"2402b902-0b7a-458c-9c07-7435a826f794"
+       }
+   }
+
+
+
+

--- a/api-docs/api-operations-v2/methods-v2/put-update-volume-v2.rst
+++ b/api-docs/api-operations-v2/methods-v2/put-update-volume-v2.rst
@@ -1,0 +1,290 @@
+
+.. _put-update-volume-v2:
+
+Update volume
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    PUT /v2/{tenant_id}/volumes/{volume_id}
+
+This operation updates a volume.
+
+
+
+This table shows the possible response codes for this operation:
+
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|200                       |OK                       |Success                  |
++--------------------------+-------------------------+-------------------------+
+
+
+Request
+""""""""""""""""
+
+
+
+
+This table shows the URI parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|{tenant_id}               |UUID *(Required)*        |The UUID of the tenant in|
+|                          |                         |a multi-tenancy cloud.   |
++--------------------------+-------------------------+-------------------------+
+|{volume_id}               |UUID *(Required)*        |The UUID of the volume.  |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+This table shows the body parameters for the request:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume**                |Dict *(Required)*        |A volume object.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **size**         |Integer *(Required)*     |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |The UUID of the source   |
+|**source_volid**          |                         |volume. The API creates  |
+|                          |                         |a new volume with the    |
+|                          |                         |same size as the source  |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean *(Optional)*     |To enable a volume to    |
+|**multiattach**           |                         |attach to more than one  |
+|                          |                         |server, set the value to |
+|                          |                         |``true``. The default is |
+|                          |                         |``false``.               |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |To create a volume from  |
+|**snapshot_id**           |                         |existing snapshot,       |
+|                          |                         |specify the UUID of the  |
+|                          |                         |volume snapshot. The     |
+|                          |                         |volume is created in the |
+|                          |                         |same availability zone   |
+|                          |                         |and with the same size   |
+|                          |                         |as the snapshot.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID *(Optional)*        |The UUID of the image    |
+|**imageRef**              |                         |from which you want to   |
+|                          |                         |create a volume.         |
+|                          |                         |Required to create a     |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String *(Optional)*      |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Dict   *(Optional)*      |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID    *(Optional)*     |The UUID of the primary  |
+|**source_replica**        |                         |volume to clone.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID    *(Optional)*     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+**Example Update volume: JSON request**
+
+
+.. code::
+
+   {
+       "volume": {
+           "name": "vol-003",
+           "description": "This is yet, another volume."
+       }
+   }
+
+
+
+
+
+
+Response
+""""""""""""""""
+
+
+This table shows the body parameters for the response:
+
++--------------------------+-------------------------+-------------------------+
+|Name                      |Type                     |Description              |
++==========================+=========================+=========================+
+|**volume**                |Dict                     |A volume object.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **status**       |String                   |The volume status.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume migration     |
+|**migration_status**      |                         |status.                  |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **user_id**      |UUID                     |The UUID of the user.    |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |List                     |Instance attachment      |
+|**attachments**           |                         |information.             |
+|                          |                         |If this volume is        |
+|                          |                         |attached to a server     |
+|                          |                         |instance, the            |
+|                          |                         |attachments list includes|
+|                          |                         |the UUID of the attached |
+|                          |                         |server, an attachment    |
+|                          |                         |UUID, the name of the    |
+|                          |                         |attached host, if any,   |
+|                          |                         |the volume UUID, the     |
+|                          |                         |device, and the device   |
+|                          |                         |UUID. Otherwise, this    |
+|                          |                         |list is empty.           |                   
++--------------------------+-------------------------+-------------------------+
+|volume.\ **links**        |Dict                     |The volume links.        |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |DateTime                 |The date and time when   |
+|**created_at**            |                         |volume was created. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC.                     |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Dict                     |One or more metadata key |
+|**metadata**              |                         |and value pairs that are |
+|                          |                         |associated with the      |
+|                          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The availability_zone.   |
+|**availability_zone**     |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**bootable**              |                         |is bootable. You can boot|
+|                          |                         |an instance from a       |
+|                          |                         |bootable volume.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |Indicates if the volume  |
+|**encrypted**             |                         |is encrypted.            |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume description.  |
+|**description**           |                         |                         |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |DateTime                 |The date and time when   |
+|**updated_at**            |                         |volume was updated. The  |
+|                          |                         |format is ISO8601:       |
+|                          |                         |CCYY-MM-DD-Thh:mm:ss+/-  |
+|                          |                         |hh:mm.The +/- value, if  |
+|                          |                         |included, is the time    |
+|                          |                         |zone as an offset from   |
+|                          |                         |UTC. If the value is not |
+|                          |                         |set, the value is        |
+|                          |                         |``null``.                |
++--------------------------+-------------------------+-------------------------+ 
+|volume.\                  |String                   |The type of volume to    |
+|**volume_type**           |                         |create, either SATA or   |
+|                          |                         |SSD. This parameter is   |
+|                          |                         |optional. If not         |
+|                          |                         |defined, the default,    |
+|                          |                         |SATA, is used.           |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume name.         |
+|**name**                  |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |String                   |The volume replication   |
+|**replication_status**    |                         |status.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the          |
+|**consistencygroup_id**   |                         |consistency group.       |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**source_volid**          |                         |volume.                  |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the source   |
+|**snapshot_id**           |                         |volume snapshot. The API |
+|                          |                         |creates a new volume     |
+|                          |                         |snapshot with the same   |
+|                          |                         |size as the source volume|
+|                          |                         |snapshot.                |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |Boolean                  |If ``true``, this volume |
+|**multiattach**           |                         |can attach to more than  |
+|                          |                         |server instance.         |
++--------------------------+-------------------------+-------------------------+
+|volume.\                  |UUID                     |The UUID of the volume.  |
+|**id**                    |                         |                         |
++--------------------------+-------------------------+-------------------------+
+|volume.\ **size**         |Integer                  |The size of the volume,  |
+|                          |                         |in gibibytes (GiB).      |  
++--------------------------+-------------------------+-------------------------+
+
+
+
+
+
+**Example Update volume: JSON response**
+
+
+.. code::
+
+   {
+       "volume": {
+           "status": "available",
+           "migration_status": null,
+           "user_id": "0eea4eabcf184061a3b6db1e0daaf010",
+           "attachments": [],
+           "links": [
+               {
+                   "href": "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+                   "rel": "bookmark"
+               }
+           ],
+           "availability_zone": "nova",
+           "bootable": "false",
+           "encrypted": false,
+           "created_at": "2015-11-29T03:01:44.000000",
+           "description": "This is yet, another volume.",
+           "updated_at": null,
+           "volume_type": "lvmdriver-1",
+           "name": "vol-003",
+           "replication_status": "disabled",
+           "consistencygroup_id": null,
+           "source_volid": null,
+           "snapshot_id": null,
+           "multiattach": false,
+           "metadata": {
+               "contents": "not junk"
+           },
+           "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+           "size": 1
+       }
+   }
+
+
+

--- a/api-docs/api-reference-v2.rst
+++ b/api-docs/api-reference-v2.rst
@@ -1,0 +1,7 @@
+.. _api-reference-v2:
+
+====================
+**API Reference v2**
+====================
+
+For v2, learn about the available Cloud Block Storage API resources and methods and see request and response examples.

--- a/api-docs/api-reference.rst
+++ b/api-docs/api-reference.rst
@@ -1,7 +1,7 @@
 .. _api-reference:
 
-===================
-**API Reference**
-===================
+====================
+**API Reference v1**
+====================
 
-Learn about the available Cloud Block Storage API resources and methods and see request and response examples.
+For v1, learn about the available Cloud Block Storage API resources and methods and see request and response examples.

--- a/api-docs/index.rst
+++ b/api-docs/index.rst
@@ -11,7 +11,8 @@ using the |apiservice|.
 
 * :ref:`Getting Started Guide<getting-started>`
 * :ref:`Developer Guide<developer-guide>`
-* :ref:`API Reference<api-reference>`
+* :ref:`API Reference v1<api-reference>`
+* :ref:`API Reference v2<api-reference-v2>`
 * :ref:`Release Notes<release-notes>`
 
 
@@ -28,5 +29,7 @@ using the |apiservice|.
    general-api-info/index
    api-reference
    api-operations/index
+   api-reference-v2
+   api-operations-v2/index-v2
    release-notes
 


### PR DESCRIPTION
Using cinder v2 API Reference info at http://developer.openstack.org/api-ref-blockstorage-v2.html
Includes only the 15 cinder v2 methods that have a lunar v1 equivalent that is already documented in the CBS Dev Guide/API Reference
