### PR TITLE
Replace polyfill

### DIFF
--- a/api-docs/_templates/scripts.html
+++ b/api-docs/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
@the2hill 
Replace: <script
    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
</script>

GitHub URL: https://developer.rackspace.com/docs/cloud-block-storage/v1/developer-guide/ is not mapping correctly to https://docs-ospc.rackspace.com/cloud-block-storage/v1/.
GitHub url link lands to 404 error page. 
Cloud please review and merge the PR.